### PR TITLE
Fifth lab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ terraform.tfstate.backup
 terraform-provider-aws_v5.38.0_x5
 credentials.auto.tfvars
 MyAWSKey.pem
+terraform_log.txt

--- a/terraform_labs/section0500/main.tf
+++ b/terraform_labs/section0500/main.tf
@@ -7,6 +7,10 @@ locals {
   team        = "api_mgmt_dev"
   application = "corp_api"
   server_name = "ec2-${var.environment}-api-${var.variables_sub_az}"
+  common_tags = {
+    Owner       = "IlyesQSC"
+    Provisoned  = "Terraform"
+  }
 }
 
 # Creating Modules 
@@ -354,17 +358,13 @@ resource "aws_instance" "web_server2" {
 # Terraform Import - lab 5
 # Usage: terraform [global options] import [options] ADDR ID
 # Importing aws_instance.aws_linux and garbing the instance ID for aws that we created manually on the ui (manually_created_instance)
-# terraform import aws_instance.aws_linux i-0469a027430740c43
+# terraform import aws_instance.aws_linux i-02a614f1b9f2c0021
 resource "aws_instance" "aws_linux" {
-  instance_type = "t2.micro"
   ami           = "ami-0843a4d6dc2130849"
-  tags_all = {
-    Name = "manually_created_instance"
-    owner = "Me"
-    provider = "Terraform lab5"
-  }
+  instance_type = "t2.micro"
+  tags = local.common_tags 
 }
-# terraform import aws_instance.aws_linux i-0469a027430740c43
+# terraform import aws_instance.aws_linux i-02a614f1b9f2c0021
 # Import successful!
 # terraform plan - returns errors 
 # terraform state list - lists the resources in the state file and check if the "aws_instance.aws_linux" has been imported/created - in has been created

--- a/terraform_labs/section0500/main.tf
+++ b/terraform_labs/section0500/main.tf
@@ -359,11 +359,11 @@ resource "aws_instance" "web_server2" {
 # Usage: terraform [global options] import [options] ADDR ID
 # Importing aws_instance.aws_linux and garbing the instance ID for aws that we created manually on the ui (manually_created_instance)
 # terraform import aws_instance.aws_linux i-02a614f1b9f2c0021
-resource "aws_instance" "aws_linux" {
+/* resource "aws_instance" "aws_linux" {
   ami           = "ami-0843a4d6dc2130849" #added form the terraform 'state show aws_instance.aws_linux' command
   instance_type = "t2.micro" #added form the terraform 'state show aws_instance.aws_linux' command
   tags = local.common_tags #added to reference the local vars tags to validate the import of the resource
-}
+} */
 # terraform import aws_instance.aws_linux i-02a614f1b9f2c0021
 # Import successful!
 # terraform plan - returns errors 

--- a/terraform_labs/section0500/main.tf
+++ b/terraform_labs/section0500/main.tf
@@ -360,9 +360,9 @@ resource "aws_instance" "web_server2" {
 # Importing aws_instance.aws_linux and garbing the instance ID for aws that we created manually on the ui (manually_created_instance)
 # terraform import aws_instance.aws_linux i-02a614f1b9f2c0021
 resource "aws_instance" "aws_linux" {
-  ami           = "ami-0843a4d6dc2130849"
-  instance_type = "t2.micro"
-  tags = local.common_tags 
+  ami           = "ami-0843a4d6dc2130849" #added form the terraform 'state show aws_instance.aws_linux' command
+  instance_type = "t2.micro" #added form the terraform 'state show aws_instance.aws_linux' command
+  tags = local.common_tags #added to reference the local vars tags to validate the import of the resource
 }
 # terraform import aws_instance.aws_linux i-02a614f1b9f2c0021
 # Import successful!

--- a/terraform_labs/section0500/main.tf
+++ b/terraform_labs/section0500/main.tf
@@ -7,10 +7,6 @@ locals {
   team        = "api_mgmt_dev"
   application = "corp_api"
   server_name = "ec2-${var.environment}-api-${var.variables_sub_az}"
-  common_tags = {
-    Owner       = "IlyesQSC"
-    Provisoned  = "Terraform"
-  }
 }
 
 # Creating Modules 
@@ -359,11 +355,10 @@ resource "aws_instance" "web_server2" {
 # Usage: terraform [global options] import [options] ADDR ID
 # Importing aws_instance.aws_linux and garbing the instance ID for aws that we created manually on the ui (manually_created_instance)
 # terraform import aws_instance.aws_linux i-02a614f1b9f2c0021
-/* resource "aws_instance" "aws_linux" {
+ resource "aws_instance" "aws_linux" {
   ami           = "ami-0843a4d6dc2130849" #added form the terraform 'state show aws_instance.aws_linux' command
   instance_type = "t2.micro" #added form the terraform 'state show aws_instance.aws_linux' command
-  tags = local.common_tags #added to reference the local vars tags to validate the import of the resource
-} */
+} 
 # terraform import aws_instance.aws_linux i-02a614f1b9f2c0021
 # Import successful!
 # terraform plan - returns errors 

--- a/terraform_labs/section0500/main.tf
+++ b/terraform_labs/section0500/main.tf
@@ -1,0 +1,315 @@
+#Retrieve the list of AZs in the current AWS region
+data "aws_availability_zones" "available" {}
+data "aws_region" "current" {}
+
+#Local Variables
+locals {
+  team        = "api_mgmt_dev"
+  application = "corp_api"
+  server_name = "ec2-${var.environment}-api-${var.variables_sub_az}"
+}
+
+# Creating Modules 
+module "subnet_addrs" {
+  source  = "hashicorp/subnets/cidr"
+  version = "1.0.0"
+
+  base_cidr_block = "10.0.0.0/22"
+  networks = [
+    {
+      name     = "module_network_a"
+      new_bits = 2
+    },
+    {
+      name     = "module_network_b"
+      new_bits = 2
+    },
+  ]
+}
+
+#Declared resource
+resource "aws_vpc" "vpc" {
+  cidr_block = var.vpc_cidr #for this you have to declare the 'vpc_cidr' variable in the variables.tf file  
+  #cidr_block = "10.0.0.0/16" #(This is the static way to declare the cidr block)
+
+  tags = {
+    Name        = var.vpc_name
+    Environment = "demo_environment"
+    Terraform   = "true"
+    Region      = data.aws_region.current.name
+  }
+}
+
+# Terraform Data Block - To Lookup Latest Ubuntu 20.04 AMI Image
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"]
+}
+
+#Deploy the private subnets
+resource "aws_subnet" "private_subnets" {
+  for_each          = var.private_subnets
+  vpc_id            = aws_vpc.vpc.id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, each.value)
+  availability_zone = tolist(data.aws_availability_zones.available.names)[each.value]
+
+  tags = {
+    Name      = each.key
+    Terraform = "true"
+  }
+}
+
+#Deploy the public subnets
+resource "aws_subnet" "public_subnets" {
+  for_each                = var.public_subnets
+  vpc_id                  = aws_vpc.vpc.id
+  cidr_block              = cidrsubnet(var.vpc_cidr, 8, each.value + 100)
+  availability_zone       = tolist(data.aws_availability_zones.available.names)[each.value]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name      = each.key
+    Terraform = "true"
+  }
+}
+
+#Create route tables for public and private subnets
+resource "aws_route_table" "public_route_table" {
+  vpc_id = aws_vpc.vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.internet_gateway.id
+    #nat_gateway_id = aws_nat_gateway.nat_gateway.id
+  }
+  tags = {
+    Name      = "demo_public_rtb"
+    Terraform = "true"
+  }
+}
+
+resource "aws_route_table" "private_route_table" {
+  vpc_id = aws_vpc.vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    # gateway_id     = aws_internet_gateway.internet_gateway.id
+    nat_gateway_id = aws_nat_gateway.nat_gateway.id
+  }
+  tags = {
+    Name      = "demo_private_rtb"
+    Terraform = "true"
+  }
+}
+
+#Create route table associations
+resource "aws_route_table_association" "public" {
+  depends_on     = [aws_subnet.public_subnets]
+  route_table_id = aws_route_table.public_route_table.id
+  for_each       = aws_subnet.public_subnets
+  subnet_id      = each.value.id
+}
+
+resource "aws_route_table_association" "private" {
+  depends_on     = [aws_subnet.private_subnets]
+  route_table_id = aws_route_table.private_route_table.id
+  for_each       = aws_subnet.private_subnets
+  subnet_id      = each.value.id
+}
+
+#Create Internet Gateway
+resource "aws_internet_gateway" "internet_gateway" {
+  vpc_id = aws_vpc.vpc.id
+  tags = {
+    Name = "demo_igw"
+  }
+}
+
+#Create EIP for NAT Gateway
+resource "aws_eip" "nat_gateway_eip" {
+  vpc        = true
+  depends_on = [aws_internet_gateway.internet_gateway]
+  tags = {
+    Name = "demo_igw_eip"
+  }
+}
+
+#Create NAT Gateway
+resource "aws_nat_gateway" "nat_gateway" {
+  depends_on    = [aws_subnet.public_subnets]
+  allocation_id = aws_eip.nat_gateway_eip.id
+  subnet_id     = aws_subnet.public_subnets["public_subnet_1"].id
+  tags = {
+    Name = "demo_nat_gateway"
+  }
+}
+
+# Terraform Resource Block - To Build EC2 instance in Public Subnet
+resource "aws_instance" "ubuntu_server" {
+  ami                         = data.aws_ami.ubuntu.id
+  instance_type               = "t2.micro"
+  subnet_id                   = aws_subnet.public_subnets["public_subnet_1"].id
+  security_groups             = [aws_security_group.vpc-ping.id, aws_security_group.ingress-ssh.id, aws_security_group.vpc-web.id]
+  associate_public_ip_address = true
+  key_name                    = aws_key_pair.generated.key_name
+
+  connection {
+    user        = "ubuntu"
+    private_key = tls_private_key.generated.private_key_pem
+    host        = self.public_ip
+  }
+
+  # Leave the first part of the block unchanged and create our `local-exec` provisioner
+  provisioner "local-exec" {
+    # Convert it to Windows/ PowerSell commands
+    command = "chmod 600 ${local_file.private_key_pem.filename}"
+  }
+
+  # Create a remote-exec provisioner block to pull down web application.
+  provisioner "remote-exec" {
+    #These commands can be run on Mac/Linux
+    #Windows users can replace it with PowerShell or native Windows commands
+    inline = [
+      #"sleep 30", # Wait for 30 seconds
+      "sudo rm -rf /tmp",
+      "sudo git clone https://github.com/hashicorp/demo-terraform-101 /tmp",
+      "sudo sh /tmp/assets/setup-web.sh",
+    ]
+  }
+
+  tags = {
+    Name = "Ubuntu EC2 Server"
+  }
+
+  lifecycle {
+    ignore_changes = [security_groups]
+  }
+}
+
+resource "aws_instance" "web_server" { #maybe add '_server'  web
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = "t2.micro" #var.instance_type
+
+  subnet_id              = aws_subnet.public_subnets["public_subnet_1"].id 
+  security_groups             = [aws_security_group.vpc-ping.id, aws_security_group.vpc-web.id]
+  associate_public_ip_address = true
+
+  tags = {
+      Name = "Web EC2 Server"
+    }
+}
+
+resource "aws_subnet" "variables-subnet" {
+  vpc_id                  = aws_vpc.vpc.id
+  cidr_block              = var.variables_sub_cidr
+  availability_zone       = var.variables_sub_az
+  map_public_ip_on_launch = var.variables_sub_auto_ip
+
+  tags = {
+    Name      = "sub-variables-${var.variables_sub_az}"
+    Terraform = "true"
+  }
+}
+
+# TLS provider - Generate key on AWS
+resource "tls_private_key" "generated" {
+  algorithm = "RSA"
+}
+
+# Grete local key that can be resued
+resource "local_file" "private_key_pem" {
+  content  = tls_private_key.generated.private_key_pem
+  filename = "MyAWSKey.pem"
+}
+
+# Associate the SSH key pair with the EC2 instance
+resource "aws_key_pair" "generated" {
+  key_name   = "MyAWSKey"
+  public_key = tls_private_key.generated.public_key_openssh
+
+  lifecycle {
+    ignore_changes = [key_name]
+  }
+}
+
+# Create a Security Group that allows SSH to your instance
+resource "aws_security_group" "ingress-ssh" {
+  name   = "allow-all-ssh"
+  vpc_id = aws_vpc.vpc.id
+  ingress {
+    cidr_blocks = [
+      "0.0.0.0/0"
+    ]
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+  }
+  // Terraform removes the default rule
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# Create Security Group - Web Traffic over the standard HTTP and HTTPS ports.
+resource "aws_security_group" "vpc-web" {
+  name        = "vpc-web-${terraform.workspace}"
+  vpc_id      = aws_vpc.vpc.id
+  description = "Web Traffic"
+  ingress {
+    description = "Allow Port 80"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Allow Port 443"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "Allow all ip and ports outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "vpc-ping" {
+  name        = "vpc-ping"
+  vpc_id      = aws_vpc.vpc.id
+  description = "ICMP for Ping Access"
+  ingress {
+    description = "Allow ICMP Traffic"
+    from_port   = -1
+    to_port     = -1
+    protocol    = "icmp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  egress {
+    description = "Allow all ip and ports outboun"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/terraform_labs/section0500/output.tf
+++ b/terraform_labs/section0500/output.tf
@@ -1,0 +1,19 @@
+output "hello-world" {
+  description = "Print a Hello World text output"
+  value       = "Hello World" #static value
+}
+
+output "vpc_id" {
+  description = "Output the ID for the primary VPC"
+  value       = aws_vpc.vpc.id
+}
+
+output "public_url" {
+  description = "Public URL for our Web Server"
+  value       = "http://${aws_instance.ubuntu_server.public_ip}/index.html"
+}
+
+output "vpc_information" {
+  description = "VPC Information about Environment"
+  value       = "Your ${aws_vpc.vpc.tags.Environment} VPC has an ID of ${aws_vpc.vpc.id}"
+}

--- a/terraform_labs/section0500/providers.tf
+++ b/terraform_labs/section0500/providers.tf
@@ -1,6 +1,14 @@
 # Configure the AWS Provider
 provider "aws" {
-  region     = "eu-west-1"
+  region     = "eu-west-3" #back to 1
   access_key = var.aws_access_key # this variable is declered in the credentials.auto.tfvars file that is not being pushed to the repository (as it is a sensitive value and should not be shared with others)
   secret_key = var.aws_secret_access_key
+
+  default_tags {
+    tags = {
+      Environment = terraform.workspace
+      Owner       = "IlyesQSC"
+      Provisoned  = "Terraform"
+    }
+  }
 }

--- a/terraform_labs/section0500/providers.tf
+++ b/terraform_labs/section0500/providers.tf
@@ -1,0 +1,6 @@
+# Configure the AWS Provider
+provider "aws" {
+  region     = "eu-west-1"
+  access_key = var.aws_access_key # this variable is declered in the credentials.auto.tfvars file that is not being pushed to the repository (as it is a sensitive value and should not be shared with others)
+  secret_key = var.aws_secret_access_key
+}

--- a/terraform_labs/section0500/providers.tf
+++ b/terraform_labs/section0500/providers.tf
@@ -1,6 +1,6 @@
 # Configure the AWS Provider
 provider "aws" {
-  region     = "eu-west-3" #back to 1
+  region     = "eu-west-1" #back to 1
   access_key = var.aws_access_key # this variable is declered in the credentials.auto.tfvars file that is not being pushed to the repository (as it is a sensitive value and should not be shared with others)
   secret_key = var.aws_secret_access_key
 

--- a/terraform_labs/section0500/readme.md
+++ b/terraform_labs/section0500/readme.md
@@ -69,7 +69,7 @@ terraform output // show the short verson
 `terraform taint  aws_instance.web_server2` flag a resource as degraded or damaged 
 `terraform untaint  aws_instance.web_server2` - remove the tainted (flagged)
 `terraform apply -replace="aws_instance.web_server2"`
-### Debug
+### Debugging Error messages  
 `terraform state list` - see the resources built in a list
 `terraform state show aws_instance.web_server2` show more detail of a resource
 ### Importing existing resources 
@@ -101,3 +101,32 @@ resource "aws_instance" "aws_linux" {
   tags = local.common_tags
 }
 ```
+### Terraform Workspaces
+Terraform uses a state files to map your configurations.  The state, belonging to a Terraform workspace, that persistent the data. Initially, the backend has a single workspace, "default", with one associated state. Workspaces is a Terraform allows us to organize infrastructure by environments (dev, qa prod) and variables in a single directory.
+`terraform workspace` 
+`terraform workspace list` 
+-  default - eu-west-1 Ireland
+- development - eu-west-3 France (Paris)
+
+Usually it is separated out into 
+- dev - staging environment
+- qa - testing
+- prod 
+
+### Terraform State CLI (Command-line interface)
+`terraform show` -a way of interacting with the `terrafom.tfstate` file that is a local copy of the state file on AWS
+`terraform state list`
+
+### Debugging Terraform 
+Log levels 
+- TRACE 
+- DEBUG 
+- INFO 
+- WARN 
+- ERROR
+
+Enable logging WSL
+`export TF_LOG=TRACE`
+Direct the logs to a file `export TF_LOG_PATH="terraform_log.txt"`
+Disable logs `export TF_LOG=""`
+`export TF_LOG_PATH=""` set the value to empty on the logfile 

--- a/terraform_labs/section0500/readme.md
+++ b/terraform_labs/section0500/readme.md
@@ -62,3 +62,42 @@ in lab0402
 terraform output -json
 terraform output // show the short verson
 ```
+
+### Formation
+`terraform fmt`
+### Terraform Taint and Replace
+`terraform taint  aws_instance.web_server2` flag a resource as degraded or damaged 
+`terraform untaint  aws_instance.web_server2` - remove the tainted (flagged)
+`terraform apply -replace="aws_instance.web_server2"`
+### Debug
+`terraform state list` - see the resources built in a list
+`terraform state show aws_instance.web_server2` show more detail of a resource
+### Importing existing resources 
+`terraform import`
+`terraform import -h` describes how to use it
+Usage: terraform [global options] import [options] ADDR ID
+Importing `aws_instance.aws_linux` and garbing the instance ID for aws that we created manually on the ui (manually_created_instance)
+`terraform import aws_instance.aws_linux i-02a614f1b9f2c0021`
+```
+resource "aws_instance" "aws_linux" {
+}
+```
+`Import successful!`
+`terraform plan` - returns errors 
+`terraform state list` - lists the resources in the state file and check if the "aws_instance.aws_linux" has been imported/created - in has been created
+`terraform state show aws_instance.aws_linux` - to see more info and copy in the missing info to the resouce block
+```
+resource "aws_instance" "aws_linux" {
+  ami           = "ami-0843a4d6dc2130849" 
+  instance_type = "t2.micro" 
+}
+```
+`terraform plan` - should return no errors and show the plan of the resources that will be created
+Added to reference the local vars tags to validate the import of the resource
+```
+resource "aws_instance" "aws_linux" {
+  ami           = "ami-0843a4d6dc2130849" 
+  instance_type = "t2.micro" 
+  tags = local.common_tags
+}
+```

--- a/terraform_labs/section0500/readme.md
+++ b/terraform_labs/section0500/readme.md
@@ -1,0 +1,64 @@
+### Own Notes
+
+## Authenticate to AWS IAM role
+IAM -> Access Management -> Users
+```Ubuntu(WSL)
+export AWS_ACCESS_KEY_ID="<YOUR ACCESS KEY>"
+export AWS_SECRET_ACCESS_KEY="<YOUR SECRET KEY>"
+```
+This has been separated out to a file called ```terrafom/credentials.auto.tfvars``` that is not being tracked by Git, as it is part of the gitignore.
+In case there is an issue with the access credentials (AuthFailure)
+Check the date and if it is out of sync update it
+```Ubuntu(WSL)
+date
+sudo date
+sudo hwclock --systohc
+sudo hwclock -s # if this doesn't work restart the pc
+```
+## Terraform style code formatting
+```Ubuntu(WSL)
+cd terraform_labs/section04 
+terraform fmt
+```
+## Validate chnages wanted to be made 
+```Ubuntu(WSL)
+terraform validate
+```
+## Create destroy resources 
+```Ubuntu(WSL)
+terraform plan
+terraform apply
+terraform destroy -auto-approve
+```
+## Current detailed (low level) state of our resources
+```Ubuntu(WSL)
+terraform show
+```
+## Current less-detailed (highlevel) state of the resources that is being managed
+```Ubuntu(WSL)
+terraform state list
+```
+## Helper command
+```Ubuntu(WSL)
+terraform -help
+```
+## Save a plan
+It will save the plan under the name we gave. In this case under "myplan"
+```Ubuntu(WSL)
+terraform plan -out myplan
+```
+Call the plan
+```Ubuntu(WSL)
+terraform apply myplan 
+```
+Plan deletion
+```Ubuntu(WSL)
+terraform plan -destroy
+terraform destroy
+```
+## Output 
+in lab0402
+```Ubuntu(WSL)
+terraform output -json
+terraform output // show the short verson
+```

--- a/terraform_labs/section0500/variables.tf
+++ b/terraform_labs/section0500/variables.tf
@@ -1,6 +1,6 @@
 variable "aws_region" {
   type    = string
-  default = "us-east-1"
+  default = "eu-west-3"
 }
 
 variable "aws_secret_access_key" {
@@ -38,7 +38,7 @@ variable "variables_sub_cidr" {
 variable "variables_sub_az" {
   description = "Availability Zone used Variables Subnet"
   type        = string
-  default     = "eu-west-1a"
+  default     = "eu-west-3a"
 }
 
 variable "variables_sub_auto_ip" {

--- a/terraform_labs/section0500/variables.tf
+++ b/terraform_labs/section0500/variables.tf
@@ -1,6 +1,6 @@
 variable "aws_region" {
   type    = string
-  default = "eu-west-3"
+  default = "eu-west-1"
 }
 
 variable "aws_secret_access_key" {
@@ -38,7 +38,7 @@ variable "variables_sub_cidr" {
 variable "variables_sub_az" {
   description = "Availability Zone used Variables Subnet"
   type        = string
-  default     = "eu-west-3a"
+  default     = "eu-west-1a"
 }
 
 variable "variables_sub_auto_ip" {

--- a/terraform_labs/section0500/variables.tf
+++ b/terraform_labs/section0500/variables.tf
@@ -1,0 +1,61 @@
+variable "aws_region" {
+  type    = string
+  default = "us-east-1"
+}
+
+variable "aws_secret_access_key" {
+  type = string
+}
+
+variable "aws_access_key" {
+  type = string
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "vpc_name" {
+  type    = string
+  default = "demo_vpc"
+}
+
+variable "public_subnets" {
+  default = {
+    "public_subnet_1" = 1
+    "public_subnet_2" = 2
+  }
+}
+
+variable "variables_sub_cidr" {
+  description = "CIDR Block for the Variables Subnet"
+  type        = string
+  default     = "10.0.202.0/24"
+}
+
+variable "variables_sub_az" {
+  description = "Availability Zone used Variables Subnet"
+  type        = string
+  default     = "eu-west-1a"
+}
+
+variable "variables_sub_auto_ip" {
+  description = "Set Automatic IP Assigment for Variables Subnet"
+  type        = bool
+  default     = "true"
+}
+
+variable "private_subnets" {
+  default = {
+    "private_subnet_1" = 1
+    "private_subnet_2" = 2
+  }
+}
+
+variable "environment" {
+  description = "Environment for deployment"
+  type        = string
+  default     = "dev"
+}

--- a/terraform_labs/section0500/versions.tf
+++ b/terraform_labs/section0500/versions.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+    # find version: https://registry.terraform.io/providers/hashicorp/http/latest
+    http = {
+      source  = "hashicorp/http"
+      version = "~> 2.1.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.1.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "2.1.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "3.1.0"
+    }
+  }
+}


### PR DESCRIPTION
### Formation
`terraform fmt`
### Terraform Taint and Replace
`terraform taint  aws_instance.web_server2` flag a resource as degraded or damaged 
`terraform untaint  aws_instance.web_server2` - remove the tainted (flagged)
`terraform apply -replace="aws_instance.web_server2"`
### Debugging Error messages  
`terraform state list` - see the resources built in a list
`terraform state show aws_instance.web_server2` show more detail of a resource
### Importing existing resources 
`terraform import`
`terraform import -h` describes how to use it
Usage: terraform [global options] import [options] ADDR ID
Importing `aws_instance.aws_linux` and garbing the instance ID for aws that we created manually on the ui (manually_created_instance)
`terraform import aws_instance.aws_linux i-02a614f1b9f2c0021`
```
resource "aws_instance" "aws_linux" {
}
```
`Import successful!`
`terraform plan` - returns errors 
`terraform state list` - lists the resources in the state file and check if the "aws_instance.aws_linux" has been imported/created - in has been created
`terraform state show aws_instance.aws_linux` - to see more info and copy in the missing info to the resouce block
```
resource "aws_instance" "aws_linux" {
  ami           = "ami-0843a4d6dc2130849" 
  instance_type = "t2.micro" 
}
```
`terraform plan` - should return no errors and show the plan of the resources that will be created
Added to reference the local vars tags to validate the import of the resource
```
resource "aws_instance" "aws_linux" {
  ami           = "ami-0843a4d6dc2130849" 
  instance_type = "t2.micro" 
  tags = local.common_tags
}
```
### Terraform Workspaces
Terraform uses a state files to map your configurations.  The state, belonging to a Terraform workspace, that persistent the data. Initially, the backend has a single workspace, "default", with one associated state. Workspaces is a Terraform allows us to organize infrastructure by environments (dev, qa prod) and variables in a single directory.
`terraform workspace` 
`terraform workspace list` 
-  default - eu-west-1 Ireland
- development - eu-west-3 France (Paris)

Usually it is separated out into 
- dev - staging environment
- qa - testing
- prod 

### Terraform State CLI (Command-line interface)
`terraform show` -a way of interacting with the `terrafom.tfstate` file that is a local copy of the state file on AWS
`terraform state list`

### Debugging Terraform 
Log levels 
- TRACE 
- DEBUG 
- INFO 
- WARN 
- ERROR

Enable logging WSL
`export TF_LOG=TRACE`
Direct the logs to a file `export TF_LOG_PATH="terraform_log.txt"`
Disable logs `export TF_LOG=""`
`export TF_LOG_PATH=""` set the value to empty on the logfile 